### PR TITLE
Kubernetes intro

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,6 @@
+# Set to true to add assignees to pull requests
+addAssignees: true
+
+# A list of reviewers to be added to pull requests (GitHub user name)
+reviewers: 
+  - express42-bot

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,48 @@
+kubernetes-intro:
+  - kubernetes-intro/*
+
+kubernetes-controllers:
+  - kubernetes-controllers/*
+  
+kubernetes-security:
+  - kubernetes-security/*
+  
+kubernetes-debug:
+  - kubernetes-debug/*
+  
+kubernetes-gitops:
+  - kubernetes-gitops/*
+
+kubernetes-logging:
+  - kubernetes-logging/*
+  
+kubernetes-monitoring:
+  - kubernetes-monitoring/*
+  
+kubernetes-networks:
+  - kubernetes-networks/*
+  
+kubernetes-operators:
+  - kubernetes-operators/*
+  
+kubernetes-production-clusters:
+  - kubernetes-production-clusters/*
+  
+kubernetes-storage:
+  - kubernetes-storage/*
+  
+kubernetes-templating:
+  - kubernetes-templating/*
+  
+kubernetes-vault:
+  - kubernetes-vault/*
+  
+kubernetes-volumes:
+  - kubernetes-volumes/*
+  
+Review Required:
+  - kubernetes-templating/*
+  - kubernetes-production-clusters/*
+  - kubernetes-monitoring/*
+  - kubernetes-logging/*
+  - kubernetes-debug/*

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,8 @@
+name: 'Auto Assign'
+on: pull_request
+
+jobs:
+  add-reviews:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@v1.1.2

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,11 @@
+name: "Pull Request Labeler"
+
+on: pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@main
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,26 @@
+name: Run tests for OTUS homework
+
+on:
+  push:
+    branches: kubernetes-*
+  pull_request:
+    branches: kubernetes-*
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout this repo
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.ref }}
+    - name: Checkout repo with tests
+      uses: actions/checkout@v2
+      with:
+        repository: "express42/otus-platform-tests"
+        ref: 2021-03
+        path: "./otus-platform-tests/"
+
+    - name: Run tests
+      run: curl https://raw.githubusercontent.com/express42/otus-platform-tests/github-actions/run.sh | bash

--- a/kubernetes-intro/README.md
+++ b/kubernetes-intro/README.md
@@ -1,0 +1,46 @@
+### Задание 1
+> kubectl get pods -n kube-sytem
+
+NAMESPACE              NAME                                        READY   STATUS    RESTARTS   AGE
+* kube-system            coredns-74ff55c5b-cjd7v                     1/1     Running   1          22d
+* kube-system            etcd-minikube                               1/1     Running   1          22d
+* kube-system            kube-apiserver-minikube                     1/1     Running   1          22d
+* kube-system            kube-controller-manager-minikube            1/1     Running   0          3m1s
+* kube-system            kube-proxy-glw7p                            1/1     Running   1          22d
+* kube-system            kube-scheduler-minikube                     1/1     Running   0          3m32s
+* kube-system            metrics-server-56c4f8c9d6-nd7zj             1/1     Running   1          4d23h
+* kube-system            storage-provisioner                         1/1     Running   2          22d
+* kubernetes-dashboard   dashboard-metrics-scraper-f6647bd8c-xc6hp   1/1     Running   1          22d
+* kubernetes-dashboard   kubernetes-dashboard-968bcb79-rkmn6         1/1     Running   2          22d
+
+**coredns-74ff55c5b-cjd7v**
+Controlled by the deployment - coredns, который создал ReplicaSet coredns-74ff55c5b. Параметр replicas: 1 определяет количество подов, которое должно быть запущено, поэтому coredns перезапускается после удаления.
+
+**etcd-minikube, kube-apiserver-minikube, kube-controller-manager-minikube, kube-scheduler-minikube** – статические поды.Запускуются kubelet из файлов, расположенных в каталоге /etc/kubernetes/manifests/. Т.к. kubelet запущен с параметром --config=/var/lib/kubelet/config.yaml, а в данном файле содержится параметр staticPodPath: /etc/kubernetes/manifests
+
+**kube-proxy-glw7p**
+Управляется через DaemonSet kube-proxy. Через DaemonSet по одному экземпляру пода запускается на каждой (в общем случае, или на некоторых) ноде, входящей в кластер.
+
+**metrics-server-56c4f8c9d6**
+Управляется через deployment metrics-server, который создаёт replicaset metrics-server-56c4f8c9d6, который через параметр replicas: 1 определяет необходимое количество подов metrics-server, которые должны находиться в работающем состоянии.
+
+**dashboard-metrics-scraper-f6647bd8c-xc6hp**
+Управляется через deployment dashboard-metrics-scraper, который создаёт replicaset dashboard-metrics-scraper-f6647bd8c, который через параметр replicas: 1 определяет необходимое количество подов metrics-server, которые должны находиться в работающем состоянии.
+
+**kubernetes-dashboard-968bcb79-rkmn6**
+Управляется через deployment kubernetes-dashboard, который создаёт replicaset kubernetes-dashboard-968bcb79, который через параметр replicas: 1 определяет необходимое количество подов metrics-server, которые должны находиться в работающем состоянии.
+
+А вот под **storage-provisioner** – это просто pod. Если удалить его через kubectl delete pod, то он не пересоздаётся.
+
+### Задание 2
+Созданы Dockerfile и манифест пода web-pod.yaml.
+
+### Задание 3
+Для запуска frontend необходимо добавить в манифести переменные окружения согласно тому как это указано в файле main.go:
+        _mustMapEnv(&svc.productCatalogSvcAddr, "PRODUCT_CATALOG_SERVICE_ADDR")_
+        _mustMapEnv(&svc.currencySvcAddr, "CURRENCY_SERVICE_ADDR")_
+        _mustMapEnv(&svc.cartSvcAddr, "CART_SERVICE_ADDR")_
+        _mustMapEnv(&svc.recommendationSvcAddr, "RECOMMENDATION_SERVICE_ADDR")_
+        _mustMapEnv(&svc.checkoutSvcAddr, "CHECKOUT_SERVICE_ADDR")_
+        _mustMapEnv(&svc.shippingSvcAddr, "SHIPPING_SERVICE_ADDR")_
+        _mustMapEnv(&svc.adSvcAddr, "AD_SERVICE_ADDR")_

--- a/kubernetes-intro/frontend-pod-healthy.yaml
+++ b/kubernetes-intro/frontend-pod-healthy.yaml
@@ -1,7 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  creationTimestamp: null
   labels:
     run: frontend
   name: frontend

--- a/kubernetes-intro/frontend-pod-healthy.yaml
+++ b/kubernetes-intro/frontend-pod-healthy.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    run: frontend
+  name: frontend
+spec:
+  containers:
+  - env:
+    - name: PRODUCT_CATALOG_SERVICE_ADDR
+      value: "productcatalogservice:3550"
+    - name: CURRENCY_SERVICE_ADDR
+      value: "currencyservice:7000"
+    - name: CART_SERVICE_ADDR
+      value: "cartservice:7070"
+    - name: RECOMMENDATION_SERVICE_ADDR
+      value: "recommendationservice:8080"
+    - name: SHIPPING_SERVICE_ADDR
+      value: "shippingservice:50051"
+    - name: CHECKOUT_SERVICE_ADDR
+      value: "checkoutservice:5050"
+    - name: AD_SERVICE_ADDR
+      value: "adservice:9555"
+    image: vyzhiga/hipster-frontend
+    name: frontend
+    resources: {}
+  restartPolicy: Never

--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: web
+  name: web
+spec:
+  containers:
+  - image: vyzhiga/otuslab2-httpd:202104041817
+    name: web
+    resources: {}
+    volumeMounts:
+      - mountPath: /app
+        name: app
+  initContainers:
+    - name: initlab2
+      image: busybox:1.31.0
+      command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+      volumeMounts:
+        - mountPath: /app
+          name: app
+  volumes:
+    - name: app
+      emptyDir: {}

--- a/kubernetes-intro/web/Dockerfile
+++ b/kubernetes-intro/web/Dockerfile
@@ -1,0 +1,14 @@
+FROM httpd:2.4
+RUN useradd --user-group --system --create-home --no-log-init --uid 1001 otuslab02
+RUN mkdir /app && chown otuslab02:otuslab02 /app && chown -R otuslab02:otuslab02 /usr/local/apache2/
+RUN sed -i 's/User daemon/User otuslab02/g' /usr/local/apache2/conf/httpd.conf && \
+    sed -i 's/Group daemon/Group otuslab02/g' /usr/local/apache2/conf/httpd.conf && \
+    sed -i 's/Listen 80/Listen 8000/g' /usr/local/apache2/conf/httpd.conf
+RUN echo '<Directory "/app">' >> /usr/local/apache2/conf/httpd.conf && \
+    echo '    Options Indexes FollowSymLinks' >> /usr/local/apache2/conf/httpd.conf && \
+    echo '    AllowOverride None' >> /usr/local/apache2/conf/httpd.conf && \
+    echo '    Require all granted' >> /usr/local/apache2/conf/httpd.conf && \
+    echo '</Directory>' >> /usr/local/apache2/conf/httpd.conf
+RUN sed -i 's/DocumentRoot \"\/usr\/local\/apache2\/htdocs\"/DocumentRoot \"\/app\"/g' /usr/local/apache2/conf/httpd.conf
+EXPOSE 8000
+USER otuslab02


### PR DESCRIPTION
### Задание 1
> kubectl get pods -n kube-sytem

NAMESPACE              NAME                                        READY   STATUS    RESTARTS   AGE
* kube-system            coredns-74ff55c5b-cjd7v                     1/1     Running   1          22d
* kube-system            etcd-minikube                               1/1     Running   1          22d
* kube-system            kube-apiserver-minikube                     1/1     Running   1          22d
* kube-system            kube-controller-manager-minikube            1/1     Running   0          3m1s
* kube-system            kube-proxy-glw7p                            1/1     Running   1          22d
* kube-system            kube-scheduler-minikube                     1/1     Running   0          3m32s
* kube-system            metrics-server-56c4f8c9d6-nd7zj             1/1     Running   1          4d23h
* kube-system            storage-provisioner                         1/1     Running   2          22d
* kubernetes-dashboard   dashboard-metrics-scraper-f6647bd8c-xc6hp   1/1     Running   1          22d
* kubernetes-dashboard   kubernetes-dashboard-968bcb79-rkmn6         1/1     Running   2          22d

**coredns-74ff55c5b-cjd7v**
Controlled by the deployment - coredns, который создал ReplicaSet coredns-74ff55c5b. Параметр replicas: 1 определяет количество подов, которое должно быть запущено, поэтому coredns перезапускается после удаления.

**etcd-minikube, kube-apiserver-minikube, kube-controller-manager-minikube, kube-scheduler-minikube** – статические поды.Запускуются kubelet из файлов, расположенных в каталоге /etc/kubernetes/manifests/. Т.к. kubelet запущен с параметром --config=/var/lib/kubelet/config.yaml, а в данном файле содержится параметр staticPodPath: /etc/kubernetes/manifests

**kube-proxy-glw7p**
Управляется через DaemonSet kube-proxy. Через DaemonSet по одному экземпляру пода запускается на каждой (в общем случае, или на некоторых) ноде, входящей в кластер.

**metrics-server-56c4f8c9d6**
Управляется через deployment metrics-server, который создаёт replicaset metrics-server-56c4f8c9d6, который через параметр replicas: 1 определяет необходимое количество подов metrics-server, которые должны находиться в работающем состоянии.

**dashboard-metrics-scraper-f6647bd8c-xc6hp**
Управляется через deployment dashboard-metrics-scraper, который создаёт replicaset dashboard-metrics-scraper-f6647bd8c, который через параметр replicas: 1 определяет необходимое количество подов metrics-server, которые должны находиться в работающем состоянии.

**kubernetes-dashboard-968bcb79-rkmn6**
Управляется через deployment kubernetes-dashboard, который создаёт replicaset kubernetes-dashboard-968bcb79, который через параметр replicas: 1 определяет необходимое количество подов metrics-server, которые должны находиться в работающем состоянии.

А вот под **storage-provisioner** – это просто pod. Если удалить его через kubectl delete pod, то он не пересоздаётся.

### Задание 2
Созданы Dockerfile и манифест пода web-pod.yaml.

### Задание 3
Для запуска frontend необходимо добавить в манифести переменные окружения согласно тому как это указано в файле main.go:
        _mustMapEnv(&svc.productCatalogSvcAddr, "PRODUCT_CATALOG_SERVICE_ADDR")_
        _mustMapEnv(&svc.currencySvcAddr, "CURRENCY_SERVICE_ADDR")_
        _mustMapEnv(&svc.cartSvcAddr, "CART_SERVICE_ADDR")_
        _mustMapEnv(&svc.recommendationSvcAddr, "RECOMMENDATION_SERVICE_ADDR")_
        _mustMapEnv(&svc.checkoutSvcAddr, "CHECKOUT_SERVICE_ADDR")_
        _mustMapEnv(&svc.shippingSvcAddr, "SHIPPING_SERVICE_ADDR")_
        _mustMapEnv(&svc.adSvcAddr, "AD_SERVICE_ADDR")_